### PR TITLE
Fix rate limits, TOC anchors, and constraint injection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 Daily email digest for Angela (RECIPIENT_EMAIL_SECRET) tracking the Taos off-grid homestead project.
-See `taos-project-context/OPUS_CONTEXT.md` for full project context.
+See `data/constraints.json` for full project configuration (budget, land criteria, builders, off-grid systems).
 
 ---
 

--- a/research_agent.py
+++ b/research_agent.py
@@ -15,7 +15,6 @@ import os
 import re
 import sys
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
@@ -26,6 +25,7 @@ DATA = ROOT / "data"
 CACHE_FILE = DATA / "research_cache.json"
 API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
 MODEL = os.environ.get("CLAUDE_MODEL", "claude-haiku-4-5-20251001")
+DELAY = int(os.environ.get("RESEARCH_DELAY", "8"))
 
 logging.basicConfig(
     level=logging.INFO,
@@ -102,7 +102,7 @@ def search(prompt: str, max_tokens: int = 1024) -> str:
             ).strip()
             return clean(raw)
         except anthropic.RateLimitError:
-            wait = min(30 * (2 ** attempt), 120)
+            wait = min(60 * (2 ** attempt), 180)
             if attempt < 2:
                 log.warning("Rate limit (%d/3), wait %ds", attempt + 1, wait)
                 time.sleep(wait)
@@ -130,7 +130,7 @@ TONE = (
 
 
 def research_land(cfg: dict) -> str:
-    """Fresh land listings and market data."""
+    """Fresh land listings, market data, and top-rated land agents."""
     areas = ", ".join(cfg["land"]["target_areas"])
     return search(f"""Current vacant land for sale in Taos County NM.
 Target areas: {areas}.
@@ -142,6 +142,10 @@ For each listing found:
 - $PRICE | ACRES acres | LOCATION | Water: [status] | Road: [type] | Source: [site] | URL
 
 Also note any market trends: price changes, new subdivisions, seasonal patterns.
+
+Also list top-rated real estate agents specializing in vacant land sales in
+Taos County NM. Focus on agents with active land listings covering
+{areas}. For each agent: Name, brokerage, phone, website, specializations.
 
 {TONE}
 Today: {now_mt().strftime('%B %d, %Y')}.""")
@@ -201,23 +205,8 @@ For listings: Price, description, location, source URL.
 Today: {now_mt().strftime('%B %d, %Y')}.""", 768)
 
 
-def research_agents() -> str:
-    """Top-rated land agents in Taos County."""
-    return search(f"""Top-rated real estate agents specializing in vacant land
-sales in Taos County, New Mexico. Focus on agents with:
-- Active land listings (not just residential homes)
-- Coverage of Tres Piedras, Arroyo Hondo, Carson, Ojo Caliente areas
-- Client reviews mentioning land, off-grid, or rural transactions
-
-For each agent: Name, brokerage, phone, website, number of land listings,
-notable reviews or specializations.
-
-{TONE}
-Today: {now_mt().strftime('%B %d, %Y')}.""", 768)
-
-
 def main() -> None:
-    """Run all research queries and write cache."""
+    """Run all research queries sequentially and write cache."""
     if not API_KEY:
         log.error("No ANTHROPIC_API_KEY set")
         sys.exit(1)
@@ -230,33 +219,22 @@ def main() -> None:
     }
 
     queries = [
-        ("land", "Land listings", lambda: research_land(cfg)),
+        ("land", "Land + agents", lambda: research_land(cfg)),
         ("builders", "Builder intel", lambda: research_builders(cfg)),
         ("offgrid", "Off-grid news", research_offgrid),
         ("bridge", "Bridge housing", research_bridge),
-        ("agents", "Land agents", research_agents),
     ]
 
-    def _run_query(
-        key: str, label: str, fn: object,
-    ) -> tuple[str, str, str]:
+    for key, label, fn in queries:
         log.info("Researching: %s", label)
         try:
             result = fn()
+            cache["sections"][key] = result
             log.info("  %s: %d chars", label, len(result))
-            return key, label, result
         except Exception as e:
             log.error("  %s FAILED: %s", label, e, exc_info=True)
-            return key, label, ""
-
-    with ThreadPoolExecutor(max_workers=3) as pool:
-        futures = {
-            pool.submit(_run_query, key, label, fn): key
-            for key, label, fn in queries
-        }
-        for future in as_completed(futures):
-            key, label, result = future.result()
-            cache["sections"][key] = result
+            cache["sections"][key] = ""
+        time.sleep(DELAY)
 
     # Write cache
     with open(CACHE_FILE, "w", encoding="utf-8") as f:

--- a/src/main.py
+++ b/src/main.py
@@ -364,7 +364,7 @@ After listings, add:
 - Lisa Cancro, Taos Properties — [taosproperties.com](https://taosproperties.com/) — 2024 Realtor of the Year, 30+ years land/commercial experience
 - Luisa Guercini, Berkshire Hathaway Taos — #1 brokerage in Taos Valley since 1987, land sale specialist
 
-Today: {today()}. Output listings first, then agent section.{research_block("land")}{research_block("agents")}""")
+Today: {today()}. Output listings first, then agent section.{research_block("land")}""")
 
 def p_builders() -> str:
     bs = CONSTRAINTS["builders"]["active"]
@@ -379,9 +379,11 @@ Bullets with links.
 Today: {today()}. Output ONLY findings.""")
 
 def p_offgrid() -> str:
+    og = CONSTRAINTS.get("offgrid_systems", {})
     return ask(f"""Off-grid and alternative housing news for northern New Mexico. Output as bullet list — no intro paragraph.
+Our planned systems: Solar: {og.get('solar', 'TBD')}. Heating: {og.get('heating', 'TBD')}. Hot water: {og.get('hot_water', 'TBD')}. Water: {og.get('water', 'TBD')}.
 Topics to cover (pick 3-4 with real news or updates):
-- NM solar incentives or legislation 2025-2026
+- NM solar incentives or legislation 2025-2026 (especially relevant to our EG4/IronRidge setup)
 - Taos County building or zoning changes
 - Alternative housing: earthships, container homes, A-frames, dome homes, park models, or creative small housing IRC/CID approvable in NM
 - NM CID updates on modular or kit homes
@@ -457,14 +459,17 @@ Today: {today()}. Output ONLY listings.""")
     return "\n\n".join(parts) if parts else ""
 
 def p_bridge() -> str:
+    bh = CONSTRAINTS.get("bridge_housing", {})
+    suppliers = ", ".join(bh.get("yurt_suppliers", ["Colorado Yurt Company", "Pacific Yurts"]))
+    rv_max = bh.get("rv_budget_max", 45000)
     return ask(f"""Bridge/temporary housing options near Taos NM. Jump straight into listings — no intro paragraph.
 
 ## Yurts
-Colorado Yurt Company + Pacific Yurts: pricing for 20-24ft insulated. Current sales? Lead times?
+{suppliers}: pricing for 20-24ft insulated. Current sales? Lead times?
 {SCRIPT}
 
 ## RV / 5th Wheel
-For sale in NM or southern CO, under $45K, year-round capable at 7000ft.
+For sale in NM or southern CO, under ${rv_max:,}, year-round capable at 7000ft.
 Each: Year, Model, Price, Location, [Link](URL)
 
 ## Furnished Rentals
@@ -636,14 +641,13 @@ def build_email(sections: dict) -> tuple[str, str]:
     sec += section("learn", "📚", "LEARNING RESOURCE", sections.get("learning",""), "#6d28d9")
     sec += section("dash", "📊", "PROJECT DASHBOARD", dashboard(), "#1B3A5C", raw_html=True)
 
-    # TOC with clickable anchor links
-    toc_links = [
-        ("action", "🔑 Action"), ("land", "🏜️ Land"),
-        ("offgrid", "⚡ Off-Grid"), ("tacoma", "🚐 Tacoma"), ("bridge", "🏕️ Housing"),
-        ("learn", "📚 Learn"), ("dash", "📊 Dashboard")]
+    # TOC — visual only (Gmail/Outlook strip id attrs, breaking anchor links)
+    toc_labels = [
+        "🔑 Action", "🏜️ Land", "⚡ Off-Grid",
+        "🚐 Tacoma", "🏕️ Housing", "📚 Learn", "📊 Dashboard"]
     toc = " &nbsp;&middot;&nbsp; ".join(
-        f'<a href="#{a}" style="color:#fff;text-decoration:none;font-size:12px;'
-        f'font-weight:500;opacity:0.9">{lbl}</a>' for a, lbl in toc_links)
+        f'<span style="color:#fff;font-size:12px;font-weight:500;'
+        f'opacity:0.9">{lbl}</span>' for lbl in toc_labels)
 
     html = f'''<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1"></head>
@@ -765,7 +769,7 @@ def main() -> None:
             log.error(f"  FAIL {label}: {e}", exc_info=True)
             return key, label, ""
 
-    with ThreadPoolExecutor(max_workers=3) as pool:
+    with ThreadPoolExecutor(max_workers=2) as pool:
         futures = {
             pool.submit(_run_stream, k, lbl, fn): k
             for k, lbl, fn in streams


### PR DESCRIPTION
## Summary
- **Rate limit fix**: Revert research_agent.py to sequential execution with 8s delay between queries. Merge agent research into land query (5→4 calls). Increase retry backoff 30s→60s. Reduce main.py workers 3→2.
- **TOC fix**: Replace broken anchor links with visual-only spans (Gmail/Outlook strip `id` attributes)
- **Constraint injection**: Inject `offgrid_systems` and `bridge_housing` from constraints.json into prompts instead of hardcoding values
- **Housekeeping**: Fix stale OPUS_CONTEXT.md reference in CLAUDE.md

## Test plan
- [ ] Trigger workflow with `force=true` and verify no 429 rate limit errors in logs
- [ ] Confirm research agent completes all 4 queries sequentially
- [ ] Confirm main.py generates all 6 sections with max 2 concurrent workers
- [ ] Verify email TOC renders as visual labels (no broken links)
- [ ] Check off-grid section mentions EG4/IronRidge system specifics
- [ ] Check bridge section uses constraints for yurt suppliers and RV budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)